### PR TITLE
Datagrid2.0

### DIFF
--- a/mysite/main/templates/main/addproject.html
+++ b/mysite/main/templates/main/addproject.html
@@ -53,7 +53,6 @@
                           <option>Dataset 2</option>
                           <option>Dataset 3</option>
                         </select>
-                        <input type="file" class="form-control" id="project_name" aria-describedby="uploadFile" aria-label="Upload">
                     </div>
 
                 </div>

--- a/mysite/main/templates/main/datagrid.html
+++ b/mysite/main/templates/main/datagrid.html
@@ -1,170 +1,189 @@
 {% extends 'main/index.html' %}
 
-{% block title %}Data Grid Template{% endblock %}
-
 {% block content %}
 
-<div class="px-0 mx-0" style="max-width: 100vw;">
+<div class="container-fluid" style="height: 94vh;">
 
-  <!-- Title -->
-  <h2 class="px-1">Data Grid</h2>
-  
-  <!-- Search Form -->
-  <form method="GET" action="{% url 'main:datagrid' %}" style="max-width: 600px; margin: auto;">
-    <div style="display: flex; align-items: center;">
-      <!-- Search Query Input -->
-      <input type="text" name="search_query" placeholder="Search..." style="flex: 1;">
-    
-      <!-- Search Button -->
-      <button class="btn btn-secondary" type="submit" style="margin-left: 5px;">Search</button>
-    </div>
-  </form>
+  <!-- Row 1 -->
+  <div class="row" style="height: 94vh;">
 
-  <!-- Data Table -->
-  <table class="table table-striped table-hover" style="max-width: 100vw;">
+    <!-- Row 1 Column 1 -->
+    <div class="col">
 
-    <!-- Column Names -->
-    <thead>
-      <tr>
-        <th>ID</th>
-        <th>Text</th>
-        <th>JSON</th>
-        <th>Source</th>
-        <th>Code</th>
-      </tr>
-    </thead>
+      <!-- Row 1 Column 1 Row 1 -->
+      <div class="row text-center" style="height: 6vh;">
 
-    <!-- Table Row Layout -->
-    <tbody class="table-group-divider">
+        <h2 class="border-bottom">Data Grid</h2>
 
-      <!-- Loop through Data -->
-      {% for doc in sample_data %}
-      <tr>
+      </div>
 
-        <!-- Data ID -->
-        <td>
-          <div class="d-inline-block text-truncate" style="min-width: 5vw;">
-          <!-- Form to submit doc ID for modal display -->
-          <form action="{% url 'main:docInfo' %}" method="post">
-            {% csrf_token %}
-            <input type="hidden" name="doc_id" value="{{ doc.id }}">
+      <!-- Row 1 Column 1 Row 2 -->
+      <div class="row" style="height: 6vh;">
 
-            <!-- Jacob's attempt at a modal V0.1 -->
-            <!-- <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">
-              {{ doc.id }}
-            </button> -->
+        <div class="col-12">
 
-            <button class="btn btn-secondary" type="submit">{{ doc.id }}</button>
+          <form method="GET" action="{% url 'main:datagrid' %}" class="row justify-content-center g-3">
+            <div class="col-auto">
+              <label for="search_query" class="visually-hidden">Search</label>
 
+              <!-- Search Query Input -->
+              {% if request.GET.search_query %}
+                <input type="text" class="form-control" id="search_query" name="search_query" placeholder="Search..." value="{{ request.GET.search_query }}">
+              {% else %}
+                <input type="text" class="form-control" id="search_query" name="search_query" placeholder="Search...">
+              {% endif %}
+            </div>
+            <div class="col-auto">
+
+              <!-- Search Button -->
+              <button type="submit" class="btn btn-secondary mb-3">Search</button>
+            </div>
           </form>
-          </div>
-        </td>
 
-        <!-- Data Text -->
-        <td class="doc_text"><div class="d-inline-block text-truncate" style="max-width: 35vw;">{{ doc.doc_text }}</div></td>
+        </div>
 
-        <!-- Data JSON -->
-        <td class="doc_json"><div class="d-inline-block text-truncate" style="max-width: 35vw">{{ doc.doc_json }}</div></td>
-
-        <!-- Data Source -->
-        <td class="doc_source"><div class="d-inline-block text-truncate" style="min-width: 10vw">{{ doc.doc_source }}</div></td>
-
-        <!-- Data Code -->
-        <td class="doc_code"><div class="d-inline-block text-truncate" style="min-width: 10vw">PlaceHolder</div></td>
-
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-
-  <!-- Pagination -->
-  <nav aria-label="pagination">
-    <ul class="pagination justify-content-center">
-
-      <!-- Check if Previous -->
-      {% if sample_data.has_previous %}
-
-        <!-- Last Page -->
-        <li class="page-item">
-          <a class="page-link" href="?page=1" aria-label="First">
-            <span aria-hidden="true">&laquo;</span>
-          </a>
-        </li>
-
-        <!-- Previous Page -->
-        <li class="page-item"><a class="page-link" href="?page={{ sample_data.previous_page_number }}">Prev</a></li>
-      {% else %}
-
-        <!-- Disable Previous Button -->
-        <li class="page-item disabled"><a class="page-link">Prev</a></li>
-      {% endif %}
-
-      <!-- Iterate +/- 5 Pages -->
-      {% for current_page in  sample_data.paginator.page_range %}
-        {% if current_page <= sample_data.number|add:5 and current_page >= sample_data.number|add:-5 %}
-
-          <!-- Check if Counter == Current Page -->
-          {% if forloop.counter == sample_data.number %}
-
-            <!-- Disable Button for Current Page -->
-            <li class="page-item disabled"><a class="page-link" href="#">{{forloop.counter}}</a></li>
-          
-          {% else %}
-
-            <!-- Button for Page Navigation -->
-            <li class="page-item"><a class="page-link" href="?page={{forloop.counter}}">{{forloop.counter}}</a></li>
-          {% endif %}
-
-        {% endif %}
-      {% endfor %}
-
-      <!-- Check if Next -->
-      {% if sample_data.has_next %}
-        
-        <!-- Next Page -->
-        <li class="page-item"><a class="page-link" href="?page={{ sample_data.next_page_number }}">Next</a></li>
-
-        <!-- First Page -->
-        <li class="page-item">
-          <a class="page-link" href="?page={{ sample_data.paginator.num_pages }}" aria-label="Last">
-            <span aria-hidden="true">&raquo;</span>
-          </a>
-        </li>
-      {% else %}
-
-        <!-- Disable Next Button -->
-        <li class="page-item disabled"><a class="page-link">Next</a></li>
-      {% endif %}
-
-    </ul>
-  </nav>
-</div>
-
-
-<!-- Maybe a GET request to populate the modal, sending the data back through the views.py
-I believe that POST request would be necessary to update the DB, or maybe something through AJAX after the
-get request? -->
-
-<div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h1 class="modal-title fs-5" id="exampleModalLabel">Modal title</h1>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
-      <div class="modal-body">
-        {{ doc.id }}
+
+      <!-- Row 1 Column 1 Row 3 -->
+      <div class="row">
+        <!-- Data Table -->
+        <table class="table table-striped table-hover" style="max-width: 100vw;">
+
+          <!-- Column Names -->
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Text</th>
+              <th>JSON</th>
+              <th>Source</th>
+              <th>Code</th>
+            </tr>
+          </thead>
+
+          <!-- Table Row Layout -->
+          <tbody class="table-group-divider">
+
+            <!-- Loop through Data -->
+            {% for doc in sample_data %}
+              <tr>
+
+                <!-- Data ID -->
+                <td>
+
+                  <div class="d-inline-block text-truncate" style="min-width: 5vw;">
+
+                    <!-- Form to submit doc ID for modal display -->
+                    <form action="{% url 'main:docInfo' %}" method="get">
+                      <input type="hidden" name="page" value="{{ sample_data.number }}">
+                      <input type="hidden" name="doc_id" value="{{ doc.id }}">
+                      <input type="hidden" name="search_query" value="{{ request.GET.search_query }}">
+                      <button class="btn btn-secondary" type="submit">{{ doc.id }}</button>
+                    </form>
+
+                  </div>
+                </td>
+
+                <!-- Data Text -->
+                <td class="doc_text">
+                  <div class="d-inline-block text-truncate" style="max-width: 35vw;">{{ doc.doc_text }}</div>
+                </td>
+
+                <!-- Data JSON -->
+                <td class="doc_json">
+                  <div class="d-inline-block text-truncate" style="max-width: 35vw">{{ doc.doc_json }}</div>
+                </td>
+
+                <!-- Data Source -->
+                <td class="doc_source">
+                  <div class="d-inline-block text-truncate" style="min-width: 10vw">{{ doc.doc_source }}</div>
+                </td>
+
+                <!-- Data Code -->
+                <td class="doc_code">
+                  <div class="d-inline-block text-truncate" style="min-width: 10vw">PlaceHolder</div>
+                </td>
+
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-secondary">Save changes</button>
+
+      <!-- Row 1 Column 1 Row 4 -->
+      <div class="row">
+
+        <!-- Pagination -->
+        <nav aria-label="pagination">
+          <ul class="pagination justify-content-center">
+
+            <!-- Check if Previous -->
+            {% if sample_data.has_previous %}
+
+              <!-- First Page -->
+              <li class="page-item">
+                <a class="page-link" href="?page=1&search_query={{ request.GET.search_query }}" aria-label="First">
+                  <span aria-hidden="true">&laquo;</span>
+                </a>
+              </li>
+
+              <!-- Previous Page -->
+              <li class="page-item">
+                <a class="page-link" href="?page={{ sample_data.previous_page_number }}&search_query={{ request.GET.search_query }}">Prev</a>
+              </li>
+            {% else %}
+
+              <!-- Disable Previous Button -->
+              <li class="page-item disabled"><a class="page-link">Prev</a></li>
+            {% endif %}
+
+            <!-- Iterate +/- 5 Pages -->
+            {% for current_page in sample_data.paginator.page_range %}
+              {% if current_page <= sample_data.number|add:5 and current_page >= sample_data.number|add:-5 %}
+
+                <!-- Check if Counter == Current Page -->
+                {% if forloop.counter == sample_data.number %}
+
+                  <!-- Disable Button for Current Page -->
+                  <li class="page-item disabled"><a class="page-link" href="#">{{forloop.counter}}</a></li>
+
+                {% else %}
+
+                  <!-- Button for Page Navigation -->
+                  <li class="page-item">
+                    <a class="page-link" href="?page={{forloop.counter}}&search_query={{ request.GET.search_query }}">{{forloop.counter}}</a>
+                  </li>
+                {% endif %}
+
+              {% endif %}
+            {% endfor %}
+
+            <!-- Check if Next -->
+            {% if sample_data.has_next %}
+
+              <!-- Next Page -->
+              <li class="page-item"><a class="page-link" href="?page={{ sample_data.next_page_number }}&search_query={{ request.GET.search_query }}">Next</a>
+              </li>
+
+              <!-- Last Page -->
+              <li class="page-item">
+                <a class="page-link" href="?page={{ sample_data.paginator.num_pages }}&search_query={{ request.GET.search_query }}" aria-label="Last">
+                  <span aria-hidden="true">&raquo;</span>
+                </a>
+              </li>
+              {% else %}
+
+              <!-- Disable Next Button -->
+              <li class="page-item disabled"><a class="page-link">Next</a></li>
+            {% endif %}
+
+          </ul>
+        </nav>
+
       </div>
+
     </div>
+
   </div>
 </div>
-
-<script>
-
-</script>
 
 {% endblock %}

--- a/mysite/main/templates/main/datagrid_modal.html
+++ b/mysite/main/templates/main/datagrid_modal.html
@@ -3,96 +3,228 @@
 
 {% block content %}
 
-<!-- <div id="sampleDataDetailsModal" class="modal">
-    <div class="modal-content">
-      <span class="close">&times;</span>
-      <h2>{{ doc.id }}</h2>
-      <p>Document Text: {{ doc.doc_text }}</p>
-      <p>Document JSON: {{ doc.doc_json }}</p>
-      <p>Document Source: {{ doc.doc_source }}</p>
-    </div>
-  </div> -->
-
-
-<div>
+<div class="container-fluid" style="height: 88vh;">
 
   <!-- Update breadcrumb to return user to the data grid page # they left -->
   <!-- Alternatively, we could do a Go Back/Previous Page button -->
   <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
     <ol class="breadcrumb">
-      <li class="breadcrumb-item"><a href="/datagrid">Data Grid</a></li>
-      <li class="breadcrumb-item active" aria-current="page">Document: {{ doc_info.doc_id }}</li>
+      <li class="breadcrumb-item"><a href="{% url 'main:datagrid' %}">Data Grid</a></li>
+      <li class="breadcrumb-item"><a href="{% url 'main:datagrid' %}?page=1&search_query={{ doc_info.search_query }}">Search {{ doc_info.search_query }}</a></li>
+      <li class="breadcrumb-item"><a href="{% url 'main:datagrid' %}?page={{ doc_info.page }}&search_query={{ doc_info.search_query }}">Page {{ doc_info.page }}</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Document {{ doc_info.doc_id }}</li>
     </ol>
   </nav>
 
   <!-- Title -->
-  <h2 class="mt-4">Post ID: {{ doc_info.doc_id }}</h2>
+  <h2 class="mt-4">Post ID: {{ doc_info.doc_id }} Page: {{ page }}</h2>
   <h3>Source: {{ doc_info.doc_source }}</h3>
 
   <div class="row mb-3 text-center">
 
-    <!-- Post Text & JSON -->
-    <div class="col-md-8 themed-grid-col">
-      <div class="pb-3">
-      </div>
-      <div class="row">
+    <div class="row">
 
-        <!-- Post Text -->
-        <div class="col-md-6 themed-grid-col">
-          <div class="card" style="width: 100%;">
-            <div class="card-body">
-              <h5 class="card-title">Post Text</h5>
-              <p class="card-text">{{ doc_info.doc_text }}</p>
+      <!-- Post Text -->
+      <div class="col-md-4 themed-grid-col">
+        <div class="card" style="width: 100%;">
+          <div class="card-header">Post Text</div>
+          <div class="card-body">
+            <p class="card-text">{{ doc_info.doc_text }}</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Post JSON -->
+      <div class="col-md-4 themed-grid-col">
+        <div class="card" style="width: 100%;">
+          <div class="card-header">Post JSON</div>
+          <div class="card-body">
+            <p class="card-text">{{ doc_info.doc_json }}</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Post JSON -->
+      <div class="col-md-4 themed-grid-col">
+        <div class="card" style="width: 100%;">
+          <div class="card-header">Variables (Add help menu for details)</div>
+          <div class="card-body mx-auto">
+            <ul class="list-group list-group-horizontal">
+              <li class="list-group-item" style="width: 125px;">Relevance</li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_relevance" value="" id="relevance_1">
+                <label class="form-check-label" for="relevance_1">1</label>
+              </li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_relevance" value="" id="relevance_2">
+                <label class="form-check-label" for="relevance_2">2</label>
+              </li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_relevance" value="" id="relevance_99"
+                  checked>
+                <label class="form-check-label" for="relevance_99">99</label>
+              </li>
+            </ul>
+            <ul class="list-group list-group-horizontal w-100">
+              <li class="list-group-item" style="width: 125px;">News</li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_news" value="" id="news_1">
+                <label class="form-check-label" for="news_1">1</label>
+              </li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_news" value="" id="news_2">
+                <label class="form-check-label" for="news_2">2</label>
+              </li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_news" value="" id="news_99" checked>
+                <label class="form-check-label" for="news_99">99</label>
+              </li>
+            </ul>
+            <ul class="list-group list-group-horizontal">
+              <li class="list-group-item" style="width: 125px;">G_misinfo</li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_g_misinfo" value="" id="g_misinfo_1">
+                <label class="form-check-label" for="g_misinfo_1">1</label>
+              </li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_g_misinfo" value="" id="g_misinfo_2">
+                <label class="form-check-label" for="g_misinfo_2">2</label>
+              </li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_g_misinfo" value="" id="g_misinfo_99"
+                  checked>
+                <label class="form-check-label" for="g_misinfo_99">99</label>
+              </li>
+            </ul>
+            <ul class="list-group list-group-horizontal">
+              <li class="list-group-item" style="width: 125px;">GC_misinfo</li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_gc_misinfo" value="" id="gc_misinfo_1">
+                <label class="form-check-label" for="gc_misinfo_1">1</label>
+              </li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_gc_misinfo" value="" id="gc_misinfo_2">
+                <label class="form-check-label" for="gc_misinfo_2">2</label>
+              </li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_gc_misinfo" value="" id="gc_misinfo_99"
+                  checked>
+                <label class="form-check-label" for="gc_misinfo_99">99</label>
+              </li>
+            </ul>
+            <ul class="list-group list-group-horizontal">
+              <li class="list-group-item" style="width: 125px;">V_misinfo</li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_v_misinfo" value="" id="v_misinfo_1">
+                <label class="form-check-label" for="v_misinfo_1">1</label>
+              </li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_v_misinfo" value="" id="v_misinfo_2">
+                <label class="form-check-label" for="v_misinfo_2">2</label>
+              </li>
+              <li class="list-group-item">
+                <input class="form-check-input me-1" type="radio" name="lg_v_misinfo" value="" id="v_misinfo_99"
+                  checked>
+                <label class="form-check-label" for="v_misinfo_99">99</label>
+              </li>
+            </ul>
+          </div>
+          <div class="card-footer">
+            <div class="d-flex justify-content-between px-3">
+              <button type="submit" class="btn btn-danger w-25">Cancel</button>
+              <button type="submit" class="btn btn-success w-25">Save</button>
             </div>
           </div>
         </div>
-
-        <!-- Post JSON -->
-        <div class="col-md-6 themed-grid-col">
-          <div class="card" style="width: 100%;">
-            <div class="card-body">
-              <h5 class="card-title">Post JSON</h5>
-              <p class="card-text">{{ doc_info.doc_json }}</p>
-            </div>
-          </div>
-        </div>
-
       </div>
     </div>
+  </div>
 
-    <!-- Codes -->
-    <div class="col-md-4 themed-grid-col">
-      <!-- Dropdown Menu -->
-      <div>
-        <label for="code_column">Post Code</label>
-        <select name="code_column" id="code_column" style="margin-left: 25px;">
-          <option value="C1">Coding Variable1</option>
-          <option value="C2">Coding Variable2</option>
-          <option value="C3">Coding Variable3</option>
-          <option value="C4">Coding Variable4</option>
-        </select>
+
+
+  <!-- Navbar -->
+  <nav aria-label="post nav">
+    <ul class="pagination justify-content-between p-3">
+      <!-- Previous Post -->
+      <li class="page-item">
+        {% if doc_info.previous_doc_id %}
+        <a class="page-link"
+          href="{% url 'main:docInfo' %}?page={{ doc_info.page }}&doc_id={{ doc_info.previous_doc_id }}&search_query={{ doc_info.search_query }}">Previous</a>
+        {% else %}
+        <span class="page-link disabled">Previous</span>
+        {% endif %}
+      </li>
+
+      <!-- Next Post -->
+      <li class="page-item">
+        {% if doc_info.next_doc_id %}
+        <a class="page-link"
+          href="{% url 'main:docInfo' %}?page={{ doc_info.page }}&doc_id={{ doc_info.next_doc_id }}&search_query={{ doc_info.search_query }}">Next</a>
+        {% else %}
+        <span class="page-link disabled">Next</span>
+        {% endif %}
+      </li>
+    </ul>
+  </nav>
+
+</div>
+
+
+
+<!-- Modal -->
+<div class="modal fade" id="externalLinkModal" tabindex="-1" aria-labelledby="externalLinkModal" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5" id="externalLinkModalLabel"><i class="bi bi-exclamation-circle-fill"></i> Alert!
+        </h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="alert alert-danger">This is an external link and its safety and authenticity can not be confirmed,
+          proceed with caution.</div>
+        <span class="modal-link-clickable"></span>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-danger" data-bs-dismiss="modal">Cancel</button>
       </div>
     </div>
-
   </div>
 </div>
 
-<!-- Search query will need to be passed to this web page
-in order for the previous and next buttons to function correctly -->
-<!-- Navbar -->
-<nav aria-label="post nav">
-  <ul class="pagination justify-content-between p-3">
+</div>
 
-        <!-- Previous Post -->
-        <li class="page-item">
-          <a class="page-link">Previous</a>
-        </li>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 
-        <!-- Next Post -->
-        <li class="page-item">
-          <a class="page-link" href="#">Next</a>
-        </li>
-  </ul>
-</nav>
+<script>
+  function linkify(str) {
+    var newStr = str.replace(/(<a href=")?((https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)))(">(.*)<\/a>)?/gi, function () {
+      var url = arguments[2];
+      var displayText = arguments[7] || arguments[2];
+      return '<a type="button" class="modal-link" data-bs-toggle="modal" data-bs-target="#externalLinkModal" data-url="' + url + '" data-display-text="' + displayText + '">' + displayText + '</a>';
+    });
+    console.log(newStr)
+    $('div').html(newStr); //fill output area
+  }
+
+  var data = $('div').html(); //get input (content)
+  linkify(data); //run function on content
+
+  $(document).ready(function () {
+    $('.modal-link').on('click', function () {
+      var url = $(this).data('url'); // Fetch URL clicked
+      var displayText = $(this).data('display-text'); // Fetch text stored in modal
+      var linkHtml = '<a href="' + url + '" target="_blank">' + displayText + '</a>'; // Create hyperlink
+      $('#externalLinkModal .modal-link-clickable').html(linkHtml); // Display hyperlink in modal
+    });
+
+    $('.list-group-item').on('click', function () {
+      var input = $(this).find('.form-check-input');  // Fetch form-check-input nested in list-group-item
+      input.prop('checked', true);  // Check input nested within list-group-item
+    })
+  });
+</script>
+
+
 
 {% endblock %}

--- a/mysite/main/templates/main/test.html
+++ b/mysite/main/templates/main/test.html
@@ -2,147 +2,162 @@
 
 {% block content %}
 
+<style>
+  .modal-link {
+    padding: 0 !important;
+    border: 0 !important;
+    margin: 0 !important;
+    color: blue;
+    text-decoration: underline;
+  }
+</style>
+
 <div class="container-fluid" style="height: 94vh;">
 
-    <!-- Row 1 -->
-    <div class="row" style="height: 94vh;">
+  <!-- <div id="sampleDataDetailsModal" class="modal">
+    <div class="modal-content">
+      <span class="close">&times;</span>
+      <h2>{{ doc.id }}</h2>
+      <p>Document Text: {{ doc.doc_text }}</p>
+      <p>Document JSON: {{ doc.doc_json }}</p>
+      <p>Document Source: {{ doc.doc_source }}</p>
+    </div>
+  </div> -->
 
-        <!-- Row 1 Column 1 -->
-        <div class="sidebar col-12 col-sm-auto d-none d-sm-block" style="max-width: max-content;">
-            <div class="row p-1 px-2 justify-content-center" style="height: 6vh;">
-                <!-- Explore -->
-                <a class="btn btn-secondary w-100 mb-2" href="/" id="explore-btn">Explore</a>
-              </div>
-              
-              <div class="row p-1 px-2 justify-content-center" style="height: 6vh;">
-                <!-- Add Project -->
-                <a class="btn btn-secondary w-100 mb-2" href="/add_project" id="add_project-btn">Add Project</a>
-              </div>
 
-              <div class="row p-1 px-2 justify-content-start" style="height: 6vh;" style="max-width: min-content;">
-              
-                <div class="list-group">
-                    <button type="button" class="list-group-item list-group-item-action" aria-current="true" id="existingProjectBtn">
-                      Existing Projects
-                    </button>
-                    <button type="button" class="list-group-item list-group-item-action" style="display: none;" id="project-1">Project 1</button>
-                    <button type="button" class="list-group-item list-group-item-action" style="display: none;" id="project-2">Project 2</button>
-                    <button type="button" class="list-group-item list-group-item-action" style="display: none;" id="project-3">Project 3</button>
-                    <button type="button" class="list-group-item list-group-item-action" style="display: none;" id="project-4">Project 4</button>
-                    <button type="button" class="list-group-item list-group-item-action" style="display: none;" id="project-5">Project 5</button>
-                  </div>
-              
-              </div>
+  <div>
 
-              <div class="row p-1 px-2 justify-content-center" style="height: 6vh;">
-                <!-- Existing Projects -->
-                <a class="btn btn-secondary w-100 mb-2" href="/existing_project" id="existing_projects-btn">Existing Projects</a>
-              </div>
-              
-              <div class="row p-1 px-2 justify-content-center" style="height: 6vh;">
-                <!-- Users -->
-                <a class="btn btn-secondary w-100 mb-2" href="/users" id="users-btn">Users</a>
-              </div>
-              
-              <div class="row p-1 px-2 justify-content-center" style="height: 6vh;">
-                <!-- Data Grid -->
-                <a class="btn btn-secondary w-100 mb-2" href="/datagrid">Data Grid</a>
-              </div>
-              
+    <!-- Update breadcrumb to return user to the data grid page # they left -->
+    <!-- Alternatively, we could do a Go Back/Previous Page button -->
+    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/datagrid">Data Grid</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Document: 9</li>
+      </ol>
+    </nav>
 
+    <!-- Title -->
+    <h2 class="mt-4">Post ID: 9</h2>
+    <h3>Source: 4chan</h3>
+
+    <div class="row mb-3 text-center">
+
+      <!-- Post Text & JSON -->
+      <div class="col-md-8 themed-grid-col">
+        <div class="pb-3">
+        </div>
+        <div class="row">
+
+          <!-- Post Text -->
+          <div class="col-md-6 themed-grid-col">
+            <div class="card" style="width: 100%;">
+              <div class="card-body">
+                <h5 class="card-title">Post Text</h5>
+                <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Post JSON -->
+          <div class="col-md-6 themed-grid-col">
+            <div class="card" style="width: 100%;">
+              <div class="card-body">
+                <h5 class="card-title">Post JSON</h5>
+                <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+              </div>
+            </div>
+          </div>
 
         </div>
+      </div>
 
-        <!-- Row 1 Column 2 -->
-        <div class="col content w-auto">
-
+      <!-- Codes -->
+      <div class="col-md-4 themed-grid-col">
+        <!-- Dropdown Menu -->
+        <div>
+          <label for="code_column">Post Code</label>
+          <select name="code_column" id="code_column" style="margin-left: 25px;">
+            <option value="C1">Coding Variable1</option>
+            <option value="C2">Coding Variable2</option>
+            <option value="C3">Coding Variable3</option>
+            <option value="C4">Coding Variable4</option>
+          </select>
         </div>
+      </div>
 
     </div>
+  </div>
+
+  <!-- Search query will need to be passed to this web page
+  in order for the previous and next buttons to function correctly -->
+  <div class="fixed-bottom py-3">
+    <!-- Navbar -->
+    <nav aria-label="post nav">
+      <ul class="pagination justify-content-between p-3">
+  
+        <!-- Previous Post -->
+        <li class="page-item">
+          <a class="page-link">Previous</a>
+        </li>
+  
+        <!-- Next Post -->
+        <li class="page-item">
+          <a class="page-link" href="#">Next</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <!-- Button trigger modal -->
+
+
+  <!-- Modal -->
+  <div class="modal fade" id="externalLinkModal" tabindex="-1" aria-labelledby="externalLinkModal" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h1 class="modal-title fs-5" id="externalLinkModalLabel"><i class="bi bi-exclamation-circle-fill"></i> Alert!</h1>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="alert alert-danger">This is an external link and its safety and authenticity can not be confirmed, proceed with caution.</div>
+          <span class="modal-link-clickable"></span>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-danger" data-bs-dismiss="modal">Cancel</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
 </div>
 
-              
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+
 <script>
-    document.addEventListener("DOMContentLoaded", function()
-    {
-      // Get URL
-      const pathname = window.location.pathname;
-  
-      // Pseudo-tokenize
-      const pathParts = pathname.split("/");
-  
-      // Get path after first /
-      const tab = pathParts[1];
-  
-      // Testing
-      console.log("Current Tab:", tab);
-  
-      // Initialize variable to hold tab
-      let sidebarButton;
-  
-      // Check which tab
-      if (tab === "add_project")
-      {
-        sidebarButton = document.getElementById("add_project-btn");
-        // console.log("You are on the Add Project tab");
-      } 
-      else if (tab === "existing_project")
-      {
-        sidebarButton = document.getElementById("existing_projects-btn");
-        // console.log("You are on the Existing Project tab");
-      } 
-      else if (tab === "users")
-      {
-        sidebarButton = document.getElementById("users-btn");
-        // console.log("You are on the Users tab");
-      } else
-      {
-        sidebarButton = document.getElementById("explore-btn");
-        // console.log("You are on the Explore tab");
-      }
-  
-      // Disable button
-      if (sidebarButton)
-      {
-        sidebarButton.classList.add("disabled");
-        sidebarButton.setAttribute("aria-disabled", "true");
-        sidebarButton.setAttribute("tabindex", "-1");
-        sidebarButton.setAttribute("href", "#");
-      }
-  
+  function linkify(str) {
+    var newStr = str.replace(/(<a href=")?((https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)))(">(.*)<\/a>)?/gi, function () {
+      var url = arguments[2];
+      var displayText = arguments[7] || arguments[2];
+      return '<a type="button" class="modal-link" data-bs-toggle="modal" data-bs-target="#externalLinkModal" data-url="' + url + '" data-display-text="' + displayText + '">' + displayText + '</a>';
     });
+    console.log(newStr)
+    $('div').html(newStr); //fill output area
+  }
 
-    const element = document.getElementById("existingProjectBtn");
-    element.addEventListener("click", myFunction);
+  var data = $('div').html(); //get input (content)
+  linkify(data); //run function on content
 
-    function myFunction() {
-        console.log("TEST CLICK");
-
-        var boolDisplay = document.getElementById("project-1").style.display;
-
-
-        
-        console.log(boolDisplay);
-
-        if (boolDisplay === "none")
-        {
-            document.getElementById("project-1").style.display = "block";
-            document.getElementById("project-2").style.display = "block";
-            document.getElementById("project-3").style.display = "block";
-            document.getElementById("project-4").style.display = "block";
-            document.getElementById("project-5").style.display = "block";
-        }
-        else
-        {
-            document.getElementById("project-1").style.display = "none";
-            document.getElementById("project-2").style.display = "none";
-            document.getElementById("project-3").style.display = "none";
-            document.getElementById("project-4").style.display = "none";
-            document.getElementById("project-5").style.display = "none";
-        }
+  $(document).ready(function () {
+    $('.modal-link').on('click', function () {
+      var url = $(this).data('url'); // Fetch URL stored in modal
+      var displayText = $(this).data('display-text'); // Fetch text stored in modal
+      var linkHtml = '<a href="' + url + '" target="_blank">' + displayText + '</a>'; // Create hyperlink
+      $('#externalLinkModal .modal-link-clickable').html(linkHtml); // Display hyperlink in modal
+    });
+  });
+</script>
 
 
-    }
-  </script>
 
 {% endblock %}


### PR DESCRIPTION
- Fixed issue where search queries in the data grid were lost after navigating between pages
- Users can now navigate between documents using 'previous' and 'next' on the data grid modal page
- If a search query is performed and a document is selected, 'previous' and 'next' iterate through search results instead of next index
- Coding variable layout has been updated to be a grid utilizing radio inputs
   - Implemented jQuery so that clicking anywhere inside of the grid selects the radio to decrease the likelihood of misclicks
- Added "cancel" and "save" buttons directly below input grid for quick selection
   - Will add a popup to notify the user that the coding variables have been saved
   - Planning to test an interface where 'next' and 'previous' buttons are accompanied by additional 'Previous, Save" and "Next, Save" buttons for quick transition between posts
- Coding variables are defaulted to '99'
   - Default value can be changed or removed depending on needs/feedback
- Hyperlinks are now highlighted and when clicked, open a confirmation modal before leaving the site
   - Links are opened in a new tab
   - Warning text: "This is an external link and its safety and authenticity can not be confirmed, proceed with caution."
   - Links must include "http" or "https"
   - "www" is insufficient to be recognized as they are more likely to be unsafe
- Added functional breadcrumbs to data grid modal to give user the ability to navigate between the home page for documents, their search query, and the page they were on before clicking on a post